### PR TITLE
title should be defined before it's referenced

### DIFF
--- a/meme/meme.py
+++ b/meme/meme.py
@@ -89,6 +89,7 @@ def cli():
         else:
             parser.error('Requires -s, -l, or args.')
     else:
+        title = None  # In case we don't find a title
         if options.search:
             matches = list_memes(options.search)
             if len(matches) > 0:


### PR DESCRIPTION
When running this `meme -s Grumpy-Old-Man "Just Had Lunch" "Tummy still growling"`, you get this traceback:

```
Traceback (most recent call last):
  File "/Users/brad/.virtualenvs/meme/bin/meme", line 8, in <module>
    load_entry_point('meme==1.0.3', 'console_scripts', 'meme')()
  File "/Users/brad/.virtualenvs/meme/lib/python2.7/site-packages/meme/meme.py", line 99, in cli
    if title:
UnboundLocalError: local variable 'title' referenced before assignment
```
